### PR TITLE
Add security measure to forgot-password

### DIFF
--- a/src/modules/token/token.service.ts
+++ b/src/modules/token/token.service.ts
@@ -115,7 +115,7 @@ export const generateAuthTokens = async (user: IUserDoc): Promise<AccessAndRefre
 export const generateResetPasswordToken = async (email: string): Promise<string> => {
   const user = await userService.getUserByEmail(email);
   if (!user) {
-    throw new ApiError(httpStatus.NOT_FOUND, 'No users found with this email');
+    throw new ApiError(httpStatus.NO_CONTENT, '');
   }
   const expires = moment().add(config.jwt.resetPasswordExpirationMinutes, 'minutes');
   const resetPasswordToken = generateToken(user.id, expires, tokenTypes.RESET_PASSWORD);


### PR DESCRIPTION
The requestor could be an attacker who is targeting a specific email or collecting a list of users of the website. If they receive a message explicitly disclosing whether an account exists or not, the information can be used by the attacker.

#21 

Replacing my pr #23 because I faced problems with TS that are beyond repair at this point 😅 